### PR TITLE
Format document after setting language completes

### DIFF
--- a/extension.ts
+++ b/extension.ts
@@ -11,8 +11,9 @@ export function activate(context: ExtensionContext) {
       return;
     }
 
-    languages.setTextDocumentLanguage(activeEditor.document, languageId);
-    commands.executeCommand('editor.action.formatDocument');
+    languages.setTextDocumentLanguage(activeEditor.document, languageId).then(() => {
+      commands.executeCommand('editor.action.formatDocument');
+    })
   };
 
   context.subscriptions.push(commands.registerCommand(command, commandHandler));


### PR DESCRIPTION
Fixes https://github.com/clemenspeters/vscode-extension-format-json/issues/1.

I think there's a race condition between the 2 commands - setting language & formatting document.

Tested locally on my machine, and it works! You may want to perform your own tests.

Can you commit your `.vscode/` directory so contributors (like me) can benefit from the project's `launch.json` file for debugging & testing.